### PR TITLE
Shorten course title + adjust year to 2019

### DIFF
--- a/runs/2019/pyladies-brno-jaro-st/info.yml
+++ b/runs/2019/pyladies-brno-jaro-st/info.yml
@@ -149,22 +149,22 @@ plan:
   date: 2019-05-22
 
 - base: asteroids
-  date: 2018-05-29
+  date: 2019-05-29
 
 - base: asteroids
   title: pokračování závěrečného projektu
   slug: asteroids-2
-  date: 2018-06-05
+  date: 2019-06-05
   materials: []
 
 - base: asteroids
   title: pokračování závěrečného projektu
   slug: asteroids-3
-  date: 2018-06-12
+  date: 2019-06-12
   materials: []
 
 - base: asteroids
   title: pokračování závěrečného projektu
   slug: asteroids-4
-  date: 2018-06-19
+  date: 2019-06-19
   materials: []

--- a/runs/2019/pyladies-brno-jaro-st/info.yml
+++ b/runs/2019/pyladies-brno-jaro-st/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz PyLadies na Fakultě informatiky MUNI
+title: Začátečnický kurz PyLadies
 subtitle: Brno - podzim 2019 - středa
 time: 18:00–20:00
 default_time:


### PR DESCRIPTION
Ten předlouhý název kurzu tam chtěl sponzor (FI MUNI), teď na středu není potřeba.